### PR TITLE
Removed the unwanted dependency with the camera.

### DIFF
--- a/Engine/Xenon/Layer.hpp
+++ b/Engine/Xenon/Layer.hpp
@@ -61,14 +61,14 @@ namespace Xenon
 		/**
 		 * Get the scene pointer.
 		 *
-		 * @return The scene pointer.
+		 * @return The scene pointer. Note that this could be nullptr!
 		 */
 		[[nodiscard]] Scene* getScene() noexcept { return m_pScene; }
 
 		/**
 		 * Get the scene pointer.
 		 *
-		 * @return The scene pointer.
+		 * @return The scene pointer. Note that this could be nullptr!
 		 */
 		[[nodiscard]] const Scene* getScene() const noexcept { return m_pScene; }
 

--- a/Engine/Xenon/Layers/ClearScreenLayer.cpp
+++ b/Engine/Xenon/Layers/ClearScreenLayer.cpp
@@ -8,8 +8,8 @@
 
 namespace Xenon
 {
-	ClearScreenLayer::ClearScreenLayer(Renderer& renderer, Backend::Camera* pCamera, const glm::vec4& color, uint32_t priority)
-		: RasterizingLayer(renderer, priority, pCamera, Backend::AttachmentType::Color)
+	ClearScreenLayer::ClearScreenLayer(Renderer& renderer, uint32_t width, uint32_t height, const glm::vec4& color, uint32_t priority)
+		: RasterizingLayer(renderer, priority, width, height, Backend::AttachmentType::Color)
 		, m_ClearColor(color)
 	{
 	}

--- a/Engine/Xenon/Layers/ClearScreenLayer.hpp
+++ b/Engine/Xenon/Layers/ClearScreenLayer.hpp
@@ -20,11 +20,12 @@ namespace Xenon
 		 * Explicit constructor.
 		 *
 		 * @param renderer The renderer reference.
-		 * @param pCamera The camera pointer used by the renderer.
+		 * @param width The width of the render target.
+		 * @param height The height of the render target.
 		 * @param color The color to set.
 		 * @param priority The priority of the layer.
 		 */
-		explicit ClearScreenLayer(Renderer& renderer, Backend::Camera* pCamera, const glm::vec4& color, uint32_t priority);
+		explicit ClearScreenLayer(Renderer& renderer, uint32_t width, uint32_t height, const glm::vec4& color, uint32_t priority);
 
 		/**
 		 * Update the layer.

--- a/Engine/Xenon/Layers/DefaultRasterizingLayer.cpp
+++ b/Engine/Xenon/Layers/DefaultRasterizingLayer.cpp
@@ -13,8 +13,8 @@
 
 namespace Xenon
 {
-	DefaultRasterizingLayer::DefaultRasterizingLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority/* = 5*/)
-		: RasterizingLayer(renderer, priority, pCamera, Backend::AttachmentType::Color | Backend::AttachmentType::Depth | Backend::AttachmentType::Stencil)
+	DefaultRasterizingLayer::DefaultRasterizingLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority/* = 5*/)
+		: RasterizingLayer(renderer, priority, width, height, Backend::AttachmentType::Color | Backend::AttachmentType::Depth | Backend::AttachmentType::Stencil)
 	{
 	}
 
@@ -29,8 +29,8 @@ namespace Xenon
 		m_pCommandRecorder->bind(m_pRasterizer.get(), { glm::vec4(0.0f, 0.0f, 0.0f, 1.0f), 1.0f, static_cast<uint32_t>(0) });
 
 		// Set the scissor and view port.
-		m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getCamera()->getWidth()), static_cast<float>(m_Renderer.getCamera()->getHeight()), 0.0f, 1.0f);
-		m_pCommandRecorder->setScissor(0, 0, m_Renderer.getCamera()->getWidth(), m_Renderer.getCamera()->getHeight());
+		m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getWindow()->getWidth()), static_cast<float>(m_Renderer.getWindow()->getHeight()), 0.0f, 1.0f);
+		m_pCommandRecorder->setScissor(0, 0, m_Renderer.getWindow()->getWidth(), m_Renderer.getWindow()->getHeight());
 
 		// Issue the draw calls.
 		issueDrawCalls();

--- a/Engine/Xenon/Layers/DefaultRasterizingLayer.hpp
+++ b/Engine/Xenon/Layers/DefaultRasterizingLayer.hpp
@@ -36,10 +36,11 @@ namespace Xenon
 		 * Explicit constructor.
 		 *
 		 * @param renderer The renderer reference.
-		 * @param pCamera The camera pointer used by the renderer.
+		 * @param width The width of the render target.
+		 * @param height The height of the render target.
 		 * @param priority The priority of the layer. Default is 5.
 		 */
-		explicit DefaultRasterizingLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority = 5);
+		explicit DefaultRasterizingLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority = 5);
 
 		/**
 		 * Destructor.

--- a/Engine/Xenon/Layers/DefaultRayTracingLayer.cpp
+++ b/Engine/Xenon/Layers/DefaultRayTracingLayer.cpp
@@ -8,8 +8,8 @@
 
 namespace Xenon
 {
-	DefaultRayTracingLayer::DefaultRayTracingLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority/* = 10*/)
-		: RayTracingLayer(renderer, priority, pCamera)
+	DefaultRayTracingLayer::DefaultRayTracingLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority/* = 10*/)
+		: RayTracingLayer(renderer, priority, width, height)
 	{
 	}
 

--- a/Engine/Xenon/Layers/DefaultRayTracingLayer.hpp
+++ b/Engine/Xenon/Layers/DefaultRayTracingLayer.hpp
@@ -34,10 +34,11 @@ namespace Xenon
 		 * Explicit constructor.
 		 *
 		 * @param renderer The renderer reference.
-		 * @param pCamera The camera which is used to render the scene.
+		 * @param width The width of the render target.
+		 * @param height The height of the render target.
 		 * @param priority The priority of the layer. Default is 10.
 		 */
-		explicit DefaultRayTracingLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority = 10);
+		explicit DefaultRayTracingLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority = 10);
 
 		/**
 		 * Destructor.

--- a/Engine/Xenon/Layers/GBufferLayer.cpp
+++ b/Engine/Xenon/Layers/GBufferLayer.cpp
@@ -28,8 +28,8 @@ namespace Xenon
 {
 	namespace Experimental
 	{
-		GBufferLayer::GBufferLayer(Renderer& renderer, Backend::Camera* pCamera, GBufferFace face /*= GBufferFace::Front*/, uint32_t priority /*= 0*/)
-			: RasterizingLayer(renderer, priority, pCamera, Backend::AttachmentType::Color | Backend::AttachmentType::Normal | Backend::AttachmentType::Position | Backend::AttachmentType::Depth)
+		GBufferLayer::GBufferLayer(Renderer& renderer, uint32_t width, uint32_t height, GBufferFace face /*= GBufferFace::Front*/, uint32_t priority /*= 0*/)
+			: RasterizingLayer(renderer, priority, width, height, Backend::AttachmentType::Color | Backend::AttachmentType::Normal | Backend::AttachmentType::Position | Backend::AttachmentType::Depth)
 			, m_pRotationBuffer(renderer.getInstance().getFactory()->createBuffer(renderer.getInstance().getBackendDevice(), sizeof(glm::mat4), Backend::BufferType::Uniform))
 			, m_Face(face)
 		{
@@ -123,8 +123,8 @@ namespace Xenon
 			m_pCommandRecorder->bind(m_pRasterizer.get(), { glm::vec4(0.0f), glm::vec4(0.0f), glm::vec4(0.0f), 1.0f });
 
 			// Set the scissor and view port.
-			m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getCamera()->getWidth()), static_cast<float>(m_Renderer.getCamera()->getHeight()), 0.0f, 1.0f);
-			m_pCommandRecorder->setScissor(0, 0, m_Renderer.getCamera()->getWidth(), m_Renderer.getCamera()->getHeight());
+			m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getWindow()->getWidth()), static_cast<float>(m_Renderer.getWindow()->getHeight()), 0.0f, 1.0f);
+			m_pCommandRecorder->setScissor(0, 0, m_Renderer.getWindow()->getWidth(), m_Renderer.getWindow()->getHeight());
 
 			// Issue the draw calls if we have a scene.
 			if (m_pScene)
@@ -192,14 +192,14 @@ namespace Xenon
 			OPTICK_EVENT();
 
 			// Get the camera information.
-			const auto position = m_Renderer.getCamera()->m_Position;
-			const auto cameraUp = m_Renderer.getCamera()->m_Up;
+			const auto position = m_pScene->getCamera()->m_Position;
+			const auto cameraUp = m_pScene->getCamera()->m_Up;
 			// const auto front = m_RotationMatrix * glm::vec4(m_Renderer.getCamera()->m_Front, 1.0f);
-
+			
 			// Calculate the view-model matrix.
 			// const auto matrix = glm::lookAt(position, position + glm::vec3(front), cameraUp);
-			const auto matrix = glm::lookAt(position, position + m_Renderer.getCamera()->m_Front, cameraUp) * m_RotationMatrix;
-
+			const auto matrix = glm::lookAt(position, position + m_pScene->getCamera()->m_Front, cameraUp) * m_RotationMatrix;
+			
 			// Copy the rotation matrix.
 			m_pRotationBuffer->write(ToBytes(glm::value_ptr(matrix)), sizeof(glm::mat4));
 		}

--- a/Engine/Xenon/Layers/GBufferLayer.hpp
+++ b/Engine/Xenon/Layers/GBufferLayer.hpp
@@ -43,11 +43,12 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param renderer The renderer reference.
-			 * @param pCamera The camera pointer used by the renderer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param face The camera's current face. Default is front (no change to the camera).
 			 * @param priority The priority of the layer. Default is 0.
 			 */
-			explicit GBufferLayer(Renderer& renderer, Backend::Camera* pCamera, GBufferFace face = GBufferFace::Front, uint32_t priority = 0);
+			explicit GBufferLayer(Renderer& renderer, uint32_t width, uint32_t height, GBufferFace face = GBufferFace::Front, uint32_t priority = 0);
 
 			/**
 			 * On pre-update function.

--- a/Engine/Xenon/Layers/LightLUT.cpp
+++ b/Engine/Xenon/Layers/LightLUT.cpp
@@ -16,8 +16,8 @@ namespace Xenon
 {
 	namespace Experimental
 	{
-		LightLUT::LightLUT(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority)
-			: RasterizingLayer(renderer, priority, pCamera, Backend::AttachmentType::Color)
+		LightLUT::LightLUT(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority)
+			: RasterizingLayer(renderer, priority, width, height, Backend::AttachmentType::Color)
 			, m_pLookUpTable(renderer.getInstance().getFactory()->createBuffer(renderer.getInstance().getBackendDevice(), sizeof(float), Backend::BufferType::Storage))
 			, m_pControlBlock(renderer.getInstance().getFactory()->createBuffer(renderer.getInstance().getBackendDevice(), sizeof(ControlBlock), Backend::BufferType::Uniform))
 		{
@@ -87,8 +87,8 @@ namespace Xenon
 			if (m_pScene)
 			{
 				// Set the scissor and view port.
-				m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getCamera()->getWidth()), static_cast<float>(m_Renderer.getCamera()->getHeight()), 0.0f, 1.0f);
-				m_pCommandRecorder->setScissor(0, 0, m_Renderer.getCamera()->getWidth(), m_Renderer.getCamera()->getHeight());
+				m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getWindow()->getWidth()), static_cast<float>(m_Renderer.getWindow()->getHeight()), 0.0f, 1.0f);
+				m_pCommandRecorder->setScissor(0, 0, m_Renderer.getWindow()->getWidth(), m_Renderer.getWindow()->getHeight());
 
 				// Issue the draw calls.
 				issueDrawCalls();

--- a/Engine/Xenon/Layers/LightLUT.hpp
+++ b/Engine/Xenon/Layers/LightLUT.hpp
@@ -39,10 +39,11 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param renderer The renderer reference.
-			 * @param pCamera The camera pointer used by the renderer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param priority The priority of the layer.
 			 */
-			explicit LightLUT(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority);
+			explicit LightLUT(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority);
 
 			/**
 			 * On pre-update function.

--- a/Engine/Xenon/Layers/OcclusionLayer.cpp
+++ b/Engine/Xenon/Layers/OcclusionLayer.cpp
@@ -14,8 +14,8 @@
 
 namespace Xenon
 {
-	OcclusionLayer::OcclusionLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority /*= 5*/)
-		: RasterizingLayer(renderer, priority, pCamera, Backend::AttachmentType::Depth | Backend::AttachmentType::Stencil)
+	OcclusionLayer::OcclusionLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority /*= 5*/)
+		: RasterizingLayer(renderer, priority, width, height, Backend::AttachmentType::Depth | Backend::AttachmentType::Stencil)
 	{
 		// Create the pipeline.
 		Backend::RasterizingPipelineSpecification specification = {};
@@ -123,8 +123,8 @@ namespace Xenon
 		auto pOcclusionSceneDescriptor = m_pOcclusionSceneDescriptors[m_pScene].get();
 
 		// Set the scissor and view port.
-		m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getCamera()->getWidth()), static_cast<float>(m_Renderer.getCamera()->getHeight()), 0.0f, 1.0f);
-		m_pCommandRecorder->setScissor(0, 0, m_Renderer.getCamera()->getWidth(), m_Renderer.getCamera()->getHeight());
+		m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getWindow()->getWidth()), static_cast<float>(m_Renderer.getWindow()->getHeight()), 0.0f, 1.0f);
+		m_pCommandRecorder->setScissor(0, 0, m_Renderer.getWindow()->getWidth(), m_Renderer.getWindow()->getHeight());
 
 		// Get the query samples structure for the current command buffer.
 		auto& querySample = m_OcclusionQuerySamples[m_pCommandRecorder->getCurrentIndex()];

--- a/Engine/Xenon/Layers/OcclusionLayer.hpp
+++ b/Engine/Xenon/Layers/OcclusionLayer.hpp
@@ -40,10 +40,11 @@ namespace Xenon
 		 * Explicit constructor.
 		 *
 		 * @param renderer The renderer reference.
-		 * @param pCamera The camera pointer used by the renderer.
+		 * @param width The width of the render target.
+		 * @param height The height of the render target.
 		 * @param priority The priority of the layer. Default is 5.
 		 */
-		explicit OcclusionLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority = 5);
+		explicit OcclusionLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority = 5);
 
 		/**
 		 * On pre-update function.

--- a/Engine/Xenon/Layers/ShadowMapLayer.cpp
+++ b/Engine/Xenon/Layers/ShadowMapLayer.cpp
@@ -15,8 +15,8 @@ namespace Xenon
 {
 	namespace Experimental
 	{
-		ShadowMapLayer::ShadowMapLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority /*= 4*/)
-			: RasterizingLayer(renderer, priority, pCamera, Backend::AttachmentType::Depth)
+		ShadowMapLayer::ShadowMapLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority /*= 4*/)
+			: RasterizingLayer(renderer, priority, width, height, Backend::AttachmentType::Depth)
 			, m_pDefaultTransformBuffer(renderer.getInstance().getFactory()->createBuffer(renderer.getInstance().getBackendDevice(), sizeof(glm::mat4), Backend::BufferType::Uniform))
 		{
 			// Create the pipeline.
@@ -52,8 +52,8 @@ namespace Xenon
 			m_pCommandRecorder->bind(m_pRasterizer.get(), { 1.0f });
 
 			// Set the scissor and view port.
-			m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getCamera()->getWidth()), static_cast<float>(m_Renderer.getCamera()->getHeight()), 0.0f, 1.0f);
-			m_pCommandRecorder->setScissor(0, 0, m_Renderer.getCamera()->getWidth(), m_Renderer.getCamera()->getHeight());
+			m_pCommandRecorder->setViewport(0.0f, 0.0f, static_cast<float>(m_Renderer.getWindow()->getWidth()), static_cast<float>(m_Renderer.getWindow()->getHeight()), 0.0f, 1.0f);
+			m_pCommandRecorder->setScissor(0, 0, m_Renderer.getWindow()->getWidth(), m_Renderer.getWindow()->getHeight());
 
 			// Issue the draw calls.
 			issueDrawCalls();
@@ -138,8 +138,8 @@ namespace Xenon
 			OPTICK_EVENT();
 
 			ShadowCamera camera = {};
-			camera.m_View = glm::lookAt(lightSource.m_Position, lightSource.m_Position + lightSource.m_Direction, m_Renderer.getCamera()->m_WorldUp);
-			camera.m_Projection = glm::perspective(glm::radians(lightSource.m_FieldAngle), m_Renderer.getCamera()->m_AspectRatio, m_Renderer.getCamera()->m_NearPlane, m_Renderer.getCamera()->m_FarPlane);
+			camera.m_View = glm::lookAt(lightSource.m_Position, lightSource.m_Position + lightSource.m_Direction, m_pScene->getCamera()->m_WorldUp);
+			camera.m_Projection = glm::perspective(glm::radians(lightSource.m_FieldAngle), m_pScene->getCamera()->m_AspectRatio, m_pScene->getCamera()->m_NearPlane, m_pScene->getCamera()->m_FarPlane);
 
 			return camera;
 		}

--- a/Engine/Xenon/Layers/ShadowMapLayer.hpp
+++ b/Engine/Xenon/Layers/ShadowMapLayer.hpp
@@ -46,10 +46,11 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param renderer The renderer reference.
-			 * @param pCamera The camera pointer used by the renderer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param priority The priority of the layer. Default is 4.
 			 */
-			explicit ShadowMapLayer(Renderer& renderer, Backend::Camera* pCamera, uint32_t priority = 4);
+			explicit ShadowMapLayer(Renderer& renderer, uint32_t width, uint32_t height, uint32_t priority = 4);
 
 			/**
 			 * Update the layer.

--- a/Engine/Xenon/RasterizingLayer.cpp
+++ b/Engine/Xenon/RasterizingLayer.cpp
@@ -12,7 +12,7 @@ namespace Xenon
 {
 	RasterizingLayer::RasterizingLayer(Renderer& renderer, uint32_t priority, Backend::Camera* pCamera, Backend::AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, Backend::MultiSamplingCount multiSampleCount /*= Backend::MultiSamplingCount::x1*/)
 		: Layer(renderer, priority)
-		, m_pRasterizer(renderer.getInstance().getFactory()->createRasterizer(renderer.getInstance().getBackendDevice(), pCamera, attachmentTypes, enableTripleBuffering, multiSampleCount))
+		, m_pRasterizer(renderer.getInstance().getFactory()->createRasterizer(renderer.getInstance().getBackendDevice(), pCamera->getWidth(), pCamera->getHeight(), attachmentTypes, enableTripleBuffering, multiSampleCount))
 	{
 	}
 

--- a/Engine/Xenon/RasterizingLayer.cpp
+++ b/Engine/Xenon/RasterizingLayer.cpp
@@ -10,9 +10,9 @@
 
 namespace Xenon
 {
-	RasterizingLayer::RasterizingLayer(Renderer& renderer, uint32_t priority, Backend::Camera* pCamera, Backend::AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, Backend::MultiSamplingCount multiSampleCount /*= Backend::MultiSamplingCount::x1*/)
+	RasterizingLayer::RasterizingLayer(Renderer& renderer, uint32_t priority, uint32_t width, uint32_t height, Backend::AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, Backend::MultiSamplingCount multiSampleCount /*= Backend::MultiSamplingCount::x1*/)
 		: Layer(renderer, priority)
-		, m_pRasterizer(renderer.getInstance().getFactory()->createRasterizer(renderer.getInstance().getBackendDevice(), pCamera->getWidth(), pCamera->getHeight(), attachmentTypes, enableTripleBuffering, multiSampleCount))
+		, m_pRasterizer(renderer.getInstance().getFactory()->createRasterizer(renderer.getInstance().getBackendDevice(), width, height, attachmentTypes, enableTripleBuffering, multiSampleCount))
 	{
 	}
 

--- a/Engine/Xenon/RasterizingLayer.hpp
+++ b/Engine/Xenon/RasterizingLayer.hpp
@@ -21,7 +21,8 @@ namespace Xenon
 		 *
 		 * @param renderer The renderer reference.
 		 * @param priority The priority of the layer.
-		 * @param pCamera The camera which is used to render the scene.
+		 * @param width The width of the render target.
+		 * @param height The height of the render target.
 		 * @param attachmentTypes The attachment types the render target should support.
 		 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 		 * @param multiSampleCount Multi-sampling count to use. Default is x1.
@@ -29,7 +30,8 @@ namespace Xenon
 		explicit RasterizingLayer(
 			Renderer& renderer,
 			uint32_t priority,
-			Backend::Camera* pCamera,
+			uint32_t width, 
+			uint32_t height,
 			Backend::AttachmentType attachmentTypes,
 			bool enableTripleBuffering = false,
 			Backend::MultiSamplingCount multiSampleCount = Backend::MultiSamplingCount::x1);

--- a/Engine/Xenon/RayTracingLayer.cpp
+++ b/Engine/Xenon/RayTracingLayer.cpp
@@ -6,9 +6,9 @@
 
 namespace Xenon
 {
-	RayTracingLayer::RayTracingLayer(Renderer& renderer, uint32_t priority, Backend::Camera* pCamera)
+	RayTracingLayer::RayTracingLayer(Renderer& renderer, uint32_t priority, uint32_t width, uint32_t height)
 		: Layer(renderer, priority)
-		, m_pRayTracer(renderer.getInstance().getFactory()->createRayTracer(renderer.getInstance().getBackendDevice(), pCamera->getWidth(), pCamera->getHeight()))
+		, m_pRayTracer(renderer.getInstance().getFactory()->createRayTracer(renderer.getInstance().getBackendDevice(), width, height))
 	{
 	}
 

--- a/Engine/Xenon/RayTracingLayer.cpp
+++ b/Engine/Xenon/RayTracingLayer.cpp
@@ -8,7 +8,7 @@ namespace Xenon
 {
 	RayTracingLayer::RayTracingLayer(Renderer& renderer, uint32_t priority, Backend::Camera* pCamera)
 		: Layer(renderer, priority)
-		, m_pRayTracer(renderer.getInstance().getFactory()->createRayTracer(renderer.getInstance().getBackendDevice(), pCamera))
+		, m_pRayTracer(renderer.getInstance().getFactory()->createRayTracer(renderer.getInstance().getBackendDevice(), pCamera->getWidth(), pCamera->getHeight()))
 	{
 	}
 

--- a/Engine/Xenon/RayTracingLayer.hpp
+++ b/Engine/Xenon/RayTracingLayer.hpp
@@ -21,9 +21,10 @@ namespace Xenon
 		 *
 		 * @param renderer The renderer reference.
 		 * @param priority The priority of the layer.
-		 * @param pCamera The camera which is used to render the scene.
+		 * @param width The width of the render target.
+		 * @param height The height of the render target.
 		 */
-		explicit RayTracingLayer(Renderer& renderer, uint32_t priority, Backend::Camera* pCamera);
+		explicit RayTracingLayer(Renderer& renderer, uint32_t priority, uint32_t width, uint32_t height);
 
 		/**
 		 * Get the color attachment from the layer.

--- a/Engine/Xenon/Renderer.cpp
+++ b/Engine/Xenon/Renderer.cpp
@@ -8,10 +8,9 @@
 
 namespace Xenon
 {
-	Renderer::Renderer(Instance& instance, Backend::Camera* pCamera, const std::string& title)
-		: m_pSwapChain(instance.getFactory()->createSwapchain(instance.getBackendDevice(), title, pCamera->getWidth(), pCamera->getHeight()))
+	Renderer::Renderer(Instance& instance, uint32_t width, uint32_t height, const std::string& title)
+		: m_pSwapChain(instance.getFactory()->createSwapchain(instance.getBackendDevice(), title, width, height))
 		, m_pCommandRecorder(instance.getFactory()->createCommandRecorder(instance.getBackendDevice(), Backend::CommandRecorderUsage::Graphics, 3))
-		, m_pCamera(pCamera)
 		, m_Instance(instance)
 	{
 		m_pCommandSubmitters.reserve(3);

--- a/Engine/Xenon/Renderer.hpp
+++ b/Engine/Xenon/Renderer.hpp
@@ -25,9 +25,11 @@ namespace Xenon
 		 *
 		 * @param instance The instance to create the rasterizing renderer with.
 		 * @param pCamera The camera pointer.
+		 * @param width The width of the window.
+		 * @param height The height of the window.
 		 * @param title The title of the renderer window.
 		 */
-		explicit Renderer(Instance& instance, Backend::Camera* pCamera, const std::string& title);
+		explicit Renderer(Instance& instance, uint32_t width, uint32_t height, const std::string& title);
 
 		/**
 		 * Update the renderer.
@@ -70,20 +72,6 @@ namespace Xenon
 		void close();
 
 	public:
-		/**
-		 * Get the attached camera pointer.
-		 *
-		 * @return The camera pointer.
-		 */
-		[[nodiscard]] Backend::Camera* getCamera() { return m_pCamera; }
-
-		/**
-		 * Get the attached camera pointer.
-		 *
-		 * @return The camera pointer.
-		 */
-		[[nodiscard]] const Backend::Camera* getCamera() const { return m_pCamera; }
-
 		/**
 		 * Get the instance to which the renderer is bound to.
 		 *

--- a/Engine/Xenon/Renderers/DefaultRenderer.cpp
+++ b/Engine/Xenon/Renderers/DefaultRenderer.cpp
@@ -10,19 +10,19 @@ namespace Xenon
 {
 	namespace Experimental
 	{
-		DefaultRenderer::DefaultRenderer(Instance& instance, Backend::Camera* pCamera, const std::string& title)
-			: Renderer(instance, pCamera, title)
+		DefaultRenderer::DefaultRenderer(Instance& instance, uint32_t width, uint32_t height, const std::string& title)
+			: Renderer(instance, width, height, title)
 		{
 			// Setup the GBuffer layers.
-			// m_pPositiveXLayer = createLayer<GBufferLayer>(pCamera, GBufferFace::PositiveX);
-			// m_pNegativeXLayer = createLayer<GBufferLayer>(pCamera, GBufferFace::NegativeX);
-			// m_pPositiveYLayer = createLayer<GBufferLayer>(pCamera, GBufferFace::PositiveY);
-			// m_pNegativeYLayer = createLayer<GBufferLayer>(pCamera, GBufferFace::NegativeY);
-			// m_pPositiveZLayer = createLayer<GBufferLayer>(pCamera, GBufferFace::PositiveZ);
-			m_pNegativeZLayer = createLayer<GBufferLayer>(pCamera, GBufferFace::NegativeZ);
+			// m_pPositiveXLayer = createLayer<GBufferLayer>(width, height, GBufferFace::PositiveX);
+			// m_pNegativeXLayer = createLayer<GBufferLayer>(width, height, GBufferFace::NegativeX);
+			// m_pPositiveYLayer = createLayer<GBufferLayer>(width, height, GBufferFace::PositiveY);
+			// m_pNegativeYLayer = createLayer<GBufferLayer>(width, height, GBufferFace::NegativeY);
+			// m_pPositiveZLayer = createLayer<GBufferLayer>(width, height, GBufferFace::PositiveZ);
+			m_pNegativeZLayer = createLayer<GBufferLayer>(width, height, GBufferFace::NegativeZ);
 
 			// Setup the direct lighting layer.
-			m_pDirectLightingLayer = createLayer<DirectLightingLayer>(pCamera->getWidth(), pCamera->getHeight());
+			m_pDirectLightingLayer = createLayer<DirectLightingLayer>(width, height);
 			// m_pDirectLightingLayer->setGBuffer(m_pPositiveXLayer);
 			// m_pDirectLightingLayer->setGBuffer(m_pNegativeXLayer);
 			// m_pDirectLightingLayer->setGBuffer(m_pPositiveYLayer);
@@ -31,7 +31,7 @@ namespace Xenon
 			m_pDirectLightingLayer->setGBuffer(m_pNegativeZLayer);
 
 			// Create the light LUT.
-			m_pLightLUT = createLayer<LightLUT>(pCamera, 0);
+			m_pLightLUT = createLayer<LightLUT>(width, height, 0);
 			m_pDirectLightingLayer->setLightLUT(m_pLightLUT);
 		}
 

--- a/Engine/Xenon/Renderers/DefaultRenderer.hpp
+++ b/Engine/Xenon/Renderers/DefaultRenderer.hpp
@@ -25,10 +25,11 @@ namespace Xenon
 			 * This will automatically initialize the object and setup the window.
 			 *
 			 * @param instance The instance to create the rasterizing renderer with.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the window.
+			 * @param height The height of the window.
 			 * @param title The title of the renderer window.
 			 */
-			explicit DefaultRenderer(Instance& instance, Backend::Camera* pCamera, const std::string& title);
+			explicit DefaultRenderer(Instance& instance, uint32_t width, uint32_t height, const std::string& title);
 
 			/**
 			 * Set the renderable scene to the layers.

--- a/Engine/XenonBackend/Core.hpp
+++ b/Engine/XenonBackend/Core.hpp
@@ -134,6 +134,104 @@ namespace Xenon
 		}
 
 		/**
+		 * Check if the format is a depth format.
+		 *
+		 * @param format The data format.
+		 * @return True if the format is a depth format.
+		 * @return False if the format is not a depth format.
+		 */
+		[[nodiscard]] constexpr bool IsDepthFormat(DataFormat format) noexcept
+		{
+			switch (format)
+			{
+			case Xenon::Backend::DataFormat::Undefined:
+			case Xenon::Backend::DataFormat::R8_SRGB:
+			case Xenon::Backend::DataFormat::R8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32_SFLOAT:
+			case Xenon::Backend::DataFormat::R8G8_SRGB:
+			case Xenon::Backend::DataFormat::R8G8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16G16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32G32_SFLOAT:
+			case Xenon::Backend::DataFormat::R8G8B8_SRGB:
+			case Xenon::Backend::DataFormat::R8G8B8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16G16B16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32G32B32_SFLOAT:
+			case Xenon::Backend::DataFormat::B8G8R8_SRGB:
+			case Xenon::Backend::DataFormat::B8G8R8_UNORMAL:
+			case Xenon::Backend::DataFormat::R8G8B8A8_SRGB:
+			case Xenon::Backend::DataFormat::R8G8B8A8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16G16B16A16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32G32B32A32_SFLOAT:
+			case Xenon::Backend::DataFormat::B8G8R8A8_SRGB:
+			case Xenon::Backend::DataFormat::B8G8R8A8_UNORMAL:
+			case Xenon::Backend::DataFormat::S8_UINT:
+				return false;
+
+			case Xenon::Backend::DataFormat::D16_SINT:
+			case Xenon::Backend::DataFormat::D32_SFLOAT:
+			case Xenon::Backend::DataFormat::D16_UNORMAL_S8_UINT:
+			case Xenon::Backend::DataFormat::D24_UNORMAL_S8_UINT:
+			case Xenon::Backend::DataFormat::D32_SFLOAT_S8_UINT:
+				return true;
+
+			default:
+				break;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Check if the data format has a stencil component.
+		 *
+		 * @param format The data format to check.
+		 * @return True if the format has a stencil component.
+		 * @return False if the format doesn't have a stencil component.
+		 */
+		[[nodiscard]] constexpr bool HasStencilComponent(DataFormat format) noexcept
+		{
+			switch (format)
+			{
+			case Xenon::Backend::DataFormat::Undefined:
+			case Xenon::Backend::DataFormat::R8_SRGB:
+			case Xenon::Backend::DataFormat::R8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32_SFLOAT:
+			case Xenon::Backend::DataFormat::R8G8_SRGB:
+			case Xenon::Backend::DataFormat::R8G8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16G16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32G32_SFLOAT:
+			case Xenon::Backend::DataFormat::R8G8B8_SRGB:
+			case Xenon::Backend::DataFormat::R8G8B8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16G16B16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32G32B32_SFLOAT:
+			case Xenon::Backend::DataFormat::B8G8R8_SRGB:
+			case Xenon::Backend::DataFormat::B8G8R8_UNORMAL:
+			case Xenon::Backend::DataFormat::R8G8B8A8_SRGB:
+			case Xenon::Backend::DataFormat::R8G8B8A8_UNORMAL:
+			case Xenon::Backend::DataFormat::R16G16B16A16_SFLOAT:
+			case Xenon::Backend::DataFormat::R32G32B32A32_SFLOAT:
+			case Xenon::Backend::DataFormat::B8G8R8A8_SRGB:
+			case Xenon::Backend::DataFormat::B8G8R8A8_UNORMAL:
+			case Xenon::Backend::DataFormat::D16_SINT:
+			case Xenon::Backend::DataFormat::D32_SFLOAT:
+				return false;
+
+			case Xenon::Backend::DataFormat::S8_UINT:
+			case Xenon::Backend::DataFormat::D16_UNORMAL_S8_UINT:
+			case Xenon::Backend::DataFormat::D24_UNORMAL_S8_UINT:
+			case Xenon::Backend::DataFormat::D32_SFLOAT_S8_UINT:
+				return true;
+
+			default:
+				break;
+			}
+
+			return false;
+		}
+
+		/**
 		 * Image type enum.
 		 */
 		enum class ImageType : uint8_t

--- a/Engine/XenonBackend/IFactory.hpp
+++ b/Engine/XenonBackend/IFactory.hpp
@@ -89,13 +89,14 @@ namespace Xenon
 			 * Create a new rasterizer.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 			 * @param multiSampleCount Multi-sampling count to use. Default is x1.
 			 * @return The rasterizer pointer.
 			 */
-			[[nodiscard]] virtual std::unique_ptr<Rasterizer> createRasterizer(Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1) = 0;
+			[[nodiscard]] virtual std::unique_ptr<Rasterizer> createRasterizer(Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1) = 0;
 
 			/**
 			 * Create a new swapchain.
@@ -187,10 +188,11 @@ namespace Xenon
 			 * Create a new ray tracer.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @return The ray tracer pointer.
 			 */
-			[[nodiscard]] virtual std::unique_ptr<RayTracer> createRayTracer(Device* pDevice, Camera* pCamera) = 0;
+			[[nodiscard]] virtual std::unique_ptr<RayTracer> createRayTracer(Device* pDevice, uint32_t width, uint32_t height) = 0;
 
 			/**
 			 * Create anew ray tracing pipeline.

--- a/Engine/XenonBackend/Rasterizer.hpp
+++ b/Engine/XenonBackend/Rasterizer.hpp
@@ -34,13 +34,14 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 			 * @param multiSampleCount Multi-sampling count to use. Default is x1.
 			 */
-			explicit Rasterizer(const Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1)
-				: RenderTarget(pDevice, pCamera, attachmentTypes), m_bEnableTripleBuffering(enableTripleBuffering), m_MultiSamplingCount(multiSampleCount) {}
+			explicit Rasterizer(const Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1)
+				: RenderTarget(pDevice, width, height, attachmentTypes), m_bEnableTripleBuffering(enableTripleBuffering), m_MultiSamplingCount(multiSampleCount) {}
 
 		public:
 			/**

--- a/Engine/XenonBackend/RayTracer.hpp
+++ b/Engine/XenonBackend/RayTracer.hpp
@@ -20,9 +20,10 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 */
-			explicit RayTracer(const Device* pDevice, Camera* pCamera) : RenderTarget(pDevice, pCamera, AttachmentType::Color) {}
+			explicit RayTracer(const Device* pDevice, uint32_t width, uint32_t height) : RenderTarget(pDevice, width, height, AttachmentType::Color) {}
 		};
 	}
 }

--- a/Engine/XenonBackend/RenderTarget.hpp
+++ b/Engine/XenonBackend/RenderTarget.hpp
@@ -21,10 +21,11 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 */
-			explicit RenderTarget([[maybe_unused]] const Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes) : m_pCamera(pCamera), m_AttachmentTypes(attachmentTypes) {}
+			explicit RenderTarget([[maybe_unused]] const Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes) : m_Width(width), m_Height(height), m_AttachmentTypes(attachmentTypes) {}
 
 			/**
 			 * Get the image attachment of the relevant attachment type.
@@ -43,21 +44,22 @@ namespace Xenon
 			[[nodiscard]] AttachmentType getAttachmentTypes() const noexcept { return m_AttachmentTypes; }
 
 			/**
-			 * Get the camera pointer.
+			 * Get the width of the render target.
 			 *
-			 * @return The camera pointer.
+			 * @return The width.
 			 */
-			[[nodiscard]] Camera* getCamera() noexcept { return m_pCamera; }
+			[[nodiscard]] uint32_t getWidth() const noexcept { return m_Width; }
 
 			/**
-			 * Get the camera pointer.
+			 * Get the height of the render target.
 			 *
-			 * @return The const camera pointer.
+			 * @return The height.
 			 */
-			[[nodiscard]] const Camera* getCamera() const noexcept { return m_pCamera; }
+			[[nodiscard]] uint32_t getHeight() const noexcept { return m_Height; }
 
 		protected:
-			Camera* m_pCamera = nullptr;
+			uint32_t m_Width = 0;
+			uint32_t m_Height = 0;
 
 			AttachmentType m_AttachmentTypes;
 		};

--- a/Engine/XenonDX12Backend/DX12CommandRecorder.cpp
+++ b/Engine/XenonDX12Backend/DX12CommandRecorder.cpp
@@ -898,8 +898,8 @@ namespace Xenon
 			desc.MissShaderTable = pDxBindingTable->getMissAddressRange();
 			desc.HitGroupTable = pDxBindingTable->getHitGroupAddressRange();
 			desc.CallableShaderTable = pDxBindingTable->getCallableAddressRange();
-			desc.Width = pRayTracer->getCamera()->getWidth();
-			desc.Height = pRayTracer->getCamera()->getHeight();
+			desc.Width = pRayTracer->getWidth();
+			desc.Height = pRayTracer->getHeight();
 			desc.Depth = 1;
 
 			m_pCurrentCommandList->DispatchRays(&desc);

--- a/Engine/XenonDX12Backend/DX12Factory.cpp
+++ b/Engine/XenonDX12Backend/DX12Factory.cpp
@@ -48,9 +48,9 @@ namespace Xenon
 			return std::make_unique<DX12Image>(pDevice->as<DX12Device>(), specification);
 		}
 
-		std::unique_ptr<Xenon::Backend::Rasterizer> DX12Factory::createRasterizer(Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
+		std::unique_ptr<Xenon::Backend::Rasterizer> DX12Factory::createRasterizer(Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
 		{
-			return std::make_unique<DX12Rasterizer>(pDevice->as<DX12Device>(), pCamera, attachmentTypes, enableTripleBuffering, multiSampleCount);
+			return std::make_unique<DX12Rasterizer>(pDevice->as<DX12Device>(), width, height, attachmentTypes, enableTripleBuffering, multiSampleCount);
 		}
 
 		std::unique_ptr<Xenon::Backend::Swapchain> DX12Factory::createSwapchain(Device* pDevice, const std::string& title, uint32_t width, uint32_t height)
@@ -98,9 +98,9 @@ namespace Xenon
 			return std::make_unique<DX12BottomLevelAccelerationStructure>(pDevice->as<DX12Device>(), geometries);
 		}
 
-		std::unique_ptr<Xenon::Backend::RayTracer> DX12Factory::createRayTracer(Device* pDevice, Camera* pCamera)
+		std::unique_ptr<Xenon::Backend::RayTracer> DX12Factory::createRayTracer(Device* pDevice, uint32_t width, uint32_t height)
 		{
-			return std::make_unique<DX12RayTracer>(pDevice->as<DX12Device>(), pCamera);
+			return std::make_unique<DX12RayTracer>(pDevice->as<DX12Device>(), width, height);
 		}
 
 		std::unique_ptr<Xenon::Backend::RayTracingPipeline> DX12Factory::createRayTracingPipeline(Device* pDevice, std::unique_ptr<PipelineCacheHandler>&& pCacheHandler, const RayTracingPipelineSpecification& specification)

--- a/Engine/XenonDX12Backend/DX12Factory.hpp
+++ b/Engine/XenonDX12Backend/DX12Factory.hpp
@@ -77,13 +77,14 @@ namespace Xenon
 			 * Create a new rasterizer.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 			 * @param multiSampleCount Multi-sampling count to use. Default is x1.
 			 * @return The rasterizer pointer.
 			 */
-			[[nodiscard]] std::unique_ptr<Rasterizer> createRasterizer(Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1) override;
+			[[nodiscard]] std::unique_ptr<Rasterizer> createRasterizer(Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1) override;
 
 			/**
 			 * Create a new swapchain.
@@ -175,10 +176,11 @@ namespace Xenon
 			 * Create a new ray tracer.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @return The ray tracer pointer.
 			 */
-			[[nodiscard]] std::unique_ptr<RayTracer> createRayTracer(Device* pDevice, Camera* pCamera) override;
+			[[nodiscard]] std::unique_ptr<RayTracer> createRayTracer(Device* pDevice, uint32_t width, uint32_t height) override;
 
 			/**
 			 * Create anew ray tracing pipeline.

--- a/Engine/XenonDX12Backend/DX12Rasterizer.cpp
+++ b/Engine/XenonDX12Backend/DX12Rasterizer.cpp
@@ -10,8 +10,8 @@ namespace Xenon
 {
 	namespace Backend
 	{
-		DX12Rasterizer::DX12Rasterizer(DX12Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
-			: Rasterizer(pDevice, pCamera, attachmentTypes, enableTripleBuffering, multiSampleCount)
+		DX12Rasterizer::DX12Rasterizer(DX12Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
+			: Rasterizer(pDevice, width, height, attachmentTypes, enableTripleBuffering, multiSampleCount)
 			, DX12DeviceBoundObject(pDevice)
 		{
 			// Setup the descriptor counts.
@@ -213,8 +213,8 @@ namespace Xenon
 		void DX12Rasterizer::setupRenderTargets()
 		{
 			ImageSpecification specification;
-			specification.m_Width = m_pCamera->getWidth();
-			specification.m_Height = m_pCamera->getHeight();
+			specification.m_Width = getWidth();
+			specification.m_Height = getHeight();
 			specification.m_EnableMipMaps = false;
 
 			D3D12_CLEAR_VALUE colorOptimizedClearValue = {};

--- a/Engine/XenonDX12Backend/DX12Rasterizer.hpp
+++ b/Engine/XenonDX12Backend/DX12Rasterizer.hpp
@@ -22,12 +22,13 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 			 * @param multiSampleCount Multi-sampling count to use. Default is x1.
 			 */
-			explicit DX12Rasterizer(DX12Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1);
+			explicit DX12Rasterizer(DX12Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1);
 
 			/**
 			 * Destructor.

--- a/Engine/XenonDX12Backend/DX12RayTracer.cpp
+++ b/Engine/XenonDX12Backend/DX12RayTracer.cpp
@@ -9,11 +9,11 @@ namespace /* anonymous */
 	/**
 	 * Get the image specification used to create the color image.
 	 */
-	[[nodiscard]] Xenon::Backend::ImageSpecification GetImageSpecification(const Xenon::Backend::Camera* pCamera) noexcept
+	[[nodiscard]] Xenon::Backend::ImageSpecification GetImageSpecification(uint32_t width, uint32_t height) noexcept
 	{
 		Xenon::Backend::ImageSpecification specification;
-		specification.m_Width = pCamera->getWidth();
-		specification.m_Height = pCamera->getHeight();
+		specification.m_Width = width;
+		specification.m_Height = height;
 		specification.m_Usage = Xenon::Backend::ImageUsage::ColorAttachment | Xenon::Backend::ImageUsage::Storage;
 		specification.m_Format = Xenon::Backend::DataFormat::R8G8B8A8_UNORMAL | Xenon::Backend::DataFormat::R8G8B8A8_SRGB;
 		specification.m_EnableMipMaps = false;
@@ -26,10 +26,10 @@ namespace Xenon
 {
 	namespace Backend
 	{
-		DX12RayTracer::DX12RayTracer(DX12Device* pDevice, Camera* pCamera)
-			: RayTracer(pDevice, pCamera)
+		DX12RayTracer::DX12RayTracer(DX12Device* pDevice, uint32_t width, uint32_t height)
+			: RayTracer(pDevice, width, height)
 			, DX12DeviceBoundObject(pDevice)
-			, m_ColorImage(pDevice, GetImageSpecification(pCamera))
+			, m_ColorImage(pDevice, GetImageSpecification(width, height))
 		{
 		}
 

--- a/Engine/XenonDX12Backend/DX12RayTracer.hpp
+++ b/Engine/XenonDX12Backend/DX12RayTracer.hpp
@@ -21,9 +21,10 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 */
-			explicit DX12RayTracer(DX12Device* pDevice, Camera* pCamera);
+			explicit DX12RayTracer(DX12Device* pDevice, uint32_t width, uint32_t height);
 
 			/**
 			 * Destructor.

--- a/Engine/XenonShaderBank/HDRIToCubemap/HDRIToCubemap.comp.hlsl
+++ b/Engine/XenonShaderBank/HDRIToCubemap/HDRIToCubemap.comp.hlsl
@@ -1,0 +1,54 @@
+Texture2D hdri : register(t0);
+RWTexture3D<float4> cubemap : register(u1);
+
+#define PI 3.141
+
+float3 GetCubemapDirectionFromIndex(uint faceIndex, uint2 coord)
+{
+	uint width, height, depth;
+	cubemap.GetDimensions(width, height, depth);
+
+    float3 direction;
+    switch (faceIndex)
+    {
+        case 0: // Positive X
+            direction = float3(1, -coord.y / height * 2 + 1, coord.x / width * 2 - 1);
+            break;
+        case 1: // Negative X
+            direction = float3(-1, -coord.y / height * 2 + 1, -coord.x / width * 2 + 1);
+            break;
+        case 2: // Positive Y
+            direction = float3(coord.x / width * 2 - 1, 1, coord.y / height * 2 - 1);
+            break;
+        case 3: // Negative Y
+            direction = float3(coord.x / width * 2 - 1, -1, -coord.y / height * 2 + 1);
+            break;
+        case 4: // Positive Z
+            direction = float3(coord.x / width * 2 - 1, -coord.y / height * 2 + 1, 1);
+            break;
+        case 5: // Negative Z
+            direction = float3(-coord.x / width * 2 + 1, -coord.y / height * 2 + 1, -1);
+            break;
+    }
+
+    return normalize(direction);
+}
+
+float2 GetEquirectangularUV(float3 direction)
+{
+    float phi = atan2(direction.z, direction.x);
+    float theta = acos(direction.y);
+    return float2(phi / (2 * PI) + 0.5, theta / PI);
+}
+
+[numthreads(32, 32, 6)]
+void main(uint3 DispatchThreadID : SV_DispatchThreadID)
+{
+    uint faceIndex = DispatchThreadID.z;
+    uint2 faceCoord = DispatchThreadID.xy;
+
+    float3 direction = GetCubemapDirectionFromIndex(faceIndex, faceCoord);
+    float2 uv = GetEquirectangularUV(direction);
+
+    cubemap[uint3(faceCoord, faceIndex)] = hdri[uv];
+}

--- a/Engine/XenonVulkanBackend/VulkanCommandRecorder.cpp
+++ b/Engine/XenonVulkanBackend/VulkanCommandRecorder.cpp
@@ -830,8 +830,8 @@ namespace Xenon
 			beginInfo.pNext = nullptr;
 			beginInfo.renderPass = pVkRenderPass->getRenderPass();
 			beginInfo.framebuffer = pVkRenderPass->getFramebuffer();
-			beginInfo.renderArea.extent.width = pVkRenderPass->getCamera()->getWidth();
-			beginInfo.renderArea.extent.height = pVkRenderPass->getCamera()->getHeight();
+			beginInfo.renderArea.extent.width = pVkRenderPass->getWidth();
+			beginInfo.renderArea.extent.height = pVkRenderPass->getHeight();
 			beginInfo.renderArea.offset.x = 0.0f;
 			beginInfo.renderArea.offset.y = 0.0f;
 			beginInfo.clearValueCount = static_cast<uint32_t>(vkClearValues.size());
@@ -1104,7 +1104,7 @@ namespace Xenon
 			const auto hitEntry = pVkBindngTable->getHitAddressRegion();
 			const auto callableEntry = pVkBindngTable->getCallableAddressRegion();
 
-			m_pDevice->getDeviceTable().vkCmdTraceRaysKHR(*m_pCurrentBuffer, &raygenEntry, &missEntry, &hitEntry, &callableEntry, pRayTracer->getCamera()->getWidth(), pRayTracer->getCamera()->getHeight(), 1);
+			m_pDevice->getDeviceTable().vkCmdTraceRaysKHR(*m_pCurrentBuffer, &raygenEntry, &missEntry, &hitEntry, &callableEntry, pRayTracer->getWidth(), pRayTracer->getHeight(), 1);
 		}
 
 		void VulkanCommandRecorder::compute(uint32_t width, uint32_t height, uint32_t depth)

--- a/Engine/XenonVulkanBackend/VulkanFactory.cpp
+++ b/Engine/XenonVulkanBackend/VulkanFactory.cpp
@@ -49,9 +49,9 @@ namespace Xenon
 			return std::make_unique<VulkanImage>(pDevice->as<VulkanDevice>(), specification);
 		}
 
-		std::unique_ptr<Xenon::Backend::Rasterizer> VulkanFactory::createRasterizer(Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
+		std::unique_ptr<Xenon::Backend::Rasterizer> VulkanFactory::createRasterizer(Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
 		{
-			return std::make_unique<VulkanRasterizer>(pDevice->as<VulkanDevice>(), pCamera, attachmentTypes, enableTripleBuffering, multiSampleCount);
+			return std::make_unique<VulkanRasterizer>(pDevice->as<VulkanDevice>(), width, height, attachmentTypes, enableTripleBuffering, multiSampleCount);
 		}
 
 		std::unique_ptr<Xenon::Backend::Swapchain> VulkanFactory::createSwapchain(Device* pDevice, const std::string& title, uint32_t width, uint32_t height)
@@ -99,9 +99,9 @@ namespace Xenon
 			return std::make_unique<VulkanBottomLevelAccelerationStructure>(pDevice->as<VulkanDevice>(), geometries);
 		}
 
-		std::unique_ptr<Xenon::Backend::RayTracer> VulkanFactory::createRayTracer(Device* pDevice, Camera* pCamera)
+		std::unique_ptr<Xenon::Backend::RayTracer> VulkanFactory::createRayTracer(Device* pDevice, uint32_t width, uint32_t height)
 		{
-			return std::make_unique<VulkanRayTracer>(pDevice->as<VulkanDevice>(), pCamera);
+			return std::make_unique<VulkanRayTracer>(pDevice->as<VulkanDevice>(), width, height);
 		}
 
 		std::unique_ptr<Xenon::Backend::RayTracingPipeline> VulkanFactory::createRayTracingPipeline(Device* pDevice, std::unique_ptr<PipelineCacheHandler>&& pCacheHandler, const RayTracingPipelineSpecification& specification)

--- a/Engine/XenonVulkanBackend/VulkanFactory.hpp
+++ b/Engine/XenonVulkanBackend/VulkanFactory.hpp
@@ -77,13 +77,14 @@ namespace Xenon
 			 * Create a new rasterizer.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 			 * @param multiSampleCount Multi-sampling count to use. Default is x1.
 			 * @return The rasterizer pointer.
 			 */
-			[[nodiscard]] std::unique_ptr<Rasterizer> createRasterizer(Device* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1) override;
+			[[nodiscard]] std::unique_ptr<Rasterizer> createRasterizer(Device* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1) override;
 
 			/**
 			 * Create a new swapchain.
@@ -175,10 +176,11 @@ namespace Xenon
 			 * Create a new ray tracer.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @return The ray tracer pointer.
 			 */
-			[[nodiscard]] std::unique_ptr<RayTracer> createRayTracer(Device* pDevice, Camera* pCamera) override;
+			[[nodiscard]] std::unique_ptr<RayTracer> createRayTracer(Device* pDevice, uint32_t width, uint32_t height) override;
 
 			/**
 			 * Create anew ray tracing pipeline.

--- a/Engine/XenonVulkanBackend/VulkanRasterizer.cpp
+++ b/Engine/XenonVulkanBackend/VulkanRasterizer.cpp
@@ -10,8 +10,8 @@ namespace Xenon
 {
 	namespace Backend
 	{
-		VulkanRasterizer::VulkanRasterizer(VulkanDevice* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
-			: Rasterizer(pDevice, pCamera, attachmentTypes, enableTripleBuffering, multiSampleCount)
+		VulkanRasterizer::VulkanRasterizer(VulkanDevice* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering /*= false*/, MultiSamplingCount multiSampleCount /*= MultiSamplingCount::x1*/)
+			: Rasterizer(pDevice, width, height, attachmentTypes, enableTripleBuffering, multiSampleCount)
 			, VulkanDeviceBoundObject(pDevice)
 		{
 			// Setup the image attachments.
@@ -111,8 +111,8 @@ namespace Xenon
 		void VulkanRasterizer::setupAttachments()
 		{
 			ImageSpecification specification;
-			specification.m_Width = m_pCamera->getWidth();
-			specification.m_Height = m_pCamera->getHeight();
+			specification.m_Width = getWidth();
+			specification.m_Height = getHeight();
 			specification.m_Depth = 1;
 			specification.m_EnableMipMaps = false;
 
@@ -273,8 +273,8 @@ namespace Xenon
 			createInfo.renderPass = m_RenderPass;
 			createInfo.attachmentCount = static_cast<uint32_t>(m_AttachmentViews.size());
 			createInfo.pAttachments = m_AttachmentViews.data();
-			createInfo.width = m_pCamera->getWidth();
-			createInfo.height = m_pCamera->getHeight();
+			createInfo.width = getWidth();
+			createInfo.height = getHeight();
 			createInfo.layers = 1;
 
 			const auto bufferCount = m_bEnableTripleBuffering ? 3 : 1;

--- a/Engine/XenonVulkanBackend/VulkanRasterizer.hpp
+++ b/Engine/XenonVulkanBackend/VulkanRasterizer.hpp
@@ -21,12 +21,13 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera which is used to render the scene.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 * @param attachmentTypes The attachment types the render target should support.
 			 * @param enableTripleBuffering Whether to enable triple-buffering. Default is false.
 			 * @param multiSampleCount Multi-sampling count to use. Default is x1.
 			 */
-			explicit VulkanRasterizer(VulkanDevice* pDevice, Camera* pCamera, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1);
+			explicit VulkanRasterizer(VulkanDevice* pDevice, uint32_t width, uint32_t height, AttachmentType attachmentTypes, bool enableTripleBuffering = false, MultiSamplingCount multiSampleCount = MultiSamplingCount::x1);
 
 			/**
 			 * Destructor.

--- a/Engine/XenonVulkanBackend/VulkanRayTracer.cpp
+++ b/Engine/XenonVulkanBackend/VulkanRayTracer.cpp
@@ -9,11 +9,11 @@ namespace /* anonymous */
 	/**
 	 * Get the image specification used to create the color image.
 	 */
-	[[nodiscard]] Xenon::Backend::ImageSpecification GetImageSpecification(const Xenon::Backend::Camera* pCamera) noexcept
+	[[nodiscard]] Xenon::Backend::ImageSpecification GetImageSpecification(uint32_t width, uint32_t height) noexcept
 	{
 		Xenon::Backend::ImageSpecification specification;
-		specification.m_Width = pCamera->getWidth();
-		specification.m_Height = pCamera->getHeight();
+		specification.m_Width = width;
+		specification.m_Height = height;
 		specification.m_Usage = Xenon::Backend::ImageUsage::ColorAttachment | Xenon::Backend::ImageUsage::Storage;
 		specification.m_Format = Xenon::Backend::DataFormat::R8G8B8A8_UNORMAL | Xenon::Backend::DataFormat::R8G8B8A8_SRGB;
 		specification.m_EnableMipMaps = false;
@@ -26,10 +26,10 @@ namespace Xenon
 {
 	namespace Backend
 	{
-		VulkanRayTracer::VulkanRayTracer(VulkanDevice* pDevice, Camera* pCamera)
-			: RayTracer(pDevice, pCamera)
+		VulkanRayTracer::VulkanRayTracer(VulkanDevice* pDevice, uint32_t width, uint32_t height)
+			: RayTracer(pDevice, width, height)
 			, VulkanDeviceBoundObject(pDevice)
-			, m_ColorImage(pDevice, GetImageSpecification(pCamera))
+			, m_ColorImage(pDevice, GetImageSpecification(width, height))
 		{
 		}
 

--- a/Engine/XenonVulkanBackend/VulkanRayTracer.hpp
+++ b/Engine/XenonVulkanBackend/VulkanRayTracer.hpp
@@ -21,9 +21,10 @@ namespace Xenon
 			 * Explicit constructor.
 			 *
 			 * @param pDevice The device pointer.
-			 * @param pCamera The camera pointer.
+			 * @param width The width of the render target.
+			 * @param height The height of the render target.
 			 */
-			explicit VulkanRayTracer(VulkanDevice* pDevice, Camera* pCamera);
+			explicit VulkanRayTracer(VulkanDevice* pDevice, uint32_t width, uint32_t height);
 
 			/**
 			 * Destructor.

--- a/Studio/CMakeLists.txt
+++ b/Studio/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
 	"UIComponent.hpp"
 	"StudioConfiguration.cpp"
 	"StudioConfiguration.hpp"
+	"Logging.hpp"
 
 	"Layers/ImGuiLayer.cpp"
 	"Layers/ImGuiLayer.hpp"

--- a/Studio/Layers/ImGuiLayer.cpp
+++ b/Studio/Layers/ImGuiLayer.cpp
@@ -47,16 +47,12 @@ ImGuiLayer::ImGuiLayer(Xenon::Renderer& renderer, uint32_t width, uint32_t heigh
 	setupDefaultMaterial();
 
 	// Setup the ImGui logger.
-	// auto logger = std::make_shared<spdlog::logger>("XenonStudio", m_UIStorage.m_pLogs);
-	// m_pDefaultLogger = spdlog::default_logger();
-	// spdlog::register_logger(logger);
-	// spdlog::set_default_logger(logger);
+	auto logger = std::make_shared<spdlog::logger>("XenonStudio", m_UIStorage.m_pLogs);
+	spdlog::register_logger(logger);
 }
 
 ImGuiLayer::~ImGuiLayer()
 {
-	// spdlog::set_default_logger(m_pDefaultLogger);
-
 	ImNodes::DestroyContext();
 	ImGui::DestroyContext();
 }

--- a/Studio/Layers/ImGuiLayer.cpp
+++ b/Studio/Layers/ImGuiLayer.cpp
@@ -32,8 +32,8 @@ namespace /* anonymous */
 	[[nodiscard]] constexpr float CreateColor256(float value) noexcept { return value / 256; }
 }
 
-ImGuiLayer::ImGuiLayer(Xenon::Renderer& renderer, Xenon::Backend::Camera* pCamera)
-	: RasterizingLayer(renderer, 100, pCamera, Xenon::Backend::AttachmentType::Color)
+ImGuiLayer::ImGuiLayer(Xenon::Renderer& renderer, uint32_t width, uint32_t height)
+	: RasterizingLayer(renderer, 100, width, height, Xenon::Backend::AttachmentType::Color)
 	, m_UIStorage(this)
 	, m_pVertexBuffers(renderer.getCommandRecorder()->getBufferCount())
 	, m_pIndexBuffers(renderer.getCommandRecorder()->getBufferCount())
@@ -70,8 +70,8 @@ bool ImGuiLayer::beginFrame(std::chrono::nanoseconds delta)
 	auto& io = ImGui::GetIO();
 
 	// Set the display size in case it was resized.
-	io.DisplaySize.x = static_cast<float>(m_Renderer.getCamera()->getWidth());
-	io.DisplaySize.y = static_cast<float>(m_Renderer.getCamera()->getHeight());
+	io.DisplaySize.x = static_cast<float>(m_Renderer.getWindow()->getWidth());
+	io.DisplaySize.y = static_cast<float>(m_Renderer.getWindow()->getHeight());
 
 	// Set the time difference.
 	io.DeltaTime = static_cast<float>(delta.count()) / std::nano::den;
@@ -318,8 +318,8 @@ uintptr_t ImGuiLayer::getImageID(Xenon::Backend::Image* pImage, Xenon::Backend::
 void ImGuiLayer::configureImGui() const
 {
 	auto& io = ImGui::GetIO();
-	io.DisplaySize.x = static_cast<float>(m_Renderer.getCamera()->getWidth());
-	io.DisplaySize.y = static_cast<float>(m_Renderer.getCamera()->getHeight());
+	io.DisplaySize.x = static_cast<float>(m_Renderer.getWindow()->getWidth());
+	io.DisplaySize.y = static_cast<float>(m_Renderer.getWindow()->getHeight());
 
 	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 	io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;

--- a/Studio/Layers/ImGuiLayer.hpp
+++ b/Studio/Layers/ImGuiLayer.hpp
@@ -53,9 +53,10 @@ public:
 	 * Explicit constructor.
 	 *
 	 * @param renderer The renderer reference.
-	 * @param pCamera The camera pointer.
+	 * @param width The width of the render target.
+	 * @param height The height of the render target.
 	 */
-	explicit ImGuiLayer(Xenon::Renderer& renderer, Xenon::Backend::Camera* pCamera);
+	explicit ImGuiLayer(Xenon::Renderer& renderer, uint32_t width, uint32_t height);
 
 	/**
 	 * Destructor.

--- a/Studio/Layers/ImGuiLayer.hpp
+++ b/Studio/Layers/ImGuiLayer.hpp
@@ -195,8 +195,6 @@ private:
 	std::unique_ptr<Xenon::Backend::Descriptor> m_pUserDescriptor = nullptr;
 	std::unique_ptr<Xenon::Backend::Buffer> m_pUniformBuffer = nullptr;
 
-	std::shared_ptr<spdlog::logger> m_pDefaultLogger = nullptr;
-
 	std::unique_ptr<Xenon::Backend::Image> m_pImage = nullptr;
 	std::unique_ptr<Xenon::Backend::ImageView> m_pImageView = nullptr;
 	std::unique_ptr<Xenon::Backend::ImageSampler> m_pSampler = nullptr;

--- a/Studio/Logging.hpp
+++ b/Studio/Logging.hpp
@@ -13,6 +13,7 @@
  * @param VA ARGS The log message to send.
  */
 #define XENON_STUDIO_LOG(level, ...)								::spdlog::get("XenonStudio")->log(level, __VA_ARGS__)
+
 #define XENON_STUDIO_LOG_FATAL(...)									XENON_STUDIO_LOG(::spdlog::level::critical, __VA_ARGS__)
 #define XENON_STUDIO_LOG_ERROR(...)									XENON_STUDIO_LOG(::spdlog::level::err, __VA_ARGS__)
 #define XENON_STUDIO_LOG_WARNING(...)								XENON_STUDIO_LOG(::spdlog::level::warn, __VA_ARGS__)

--- a/Studio/Logging.hpp
+++ b/Studio/Logging.hpp
@@ -1,0 +1,19 @@
+// Copyright 2022-2023 Dhiraj Wishal
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <spdlog/spdlog.h>
+
+/**
+ * Xenon studio logger.
+ * Compared to the Xenon logger, this will log everything to the studio's logger instead.
+ *
+ * @param level The log level.
+ * @param VA ARGS The log message to send.
+ */
+#define XENON_STUDIO_LOG(level, ...)								::spdlog::get("XenonStudio")->log(level, __VA_ARGS__)
+#define XENON_STUDIO_LOG_FATAL(...)									XENON_STUDIO_LOG(::spdlog::level::critical, __VA_ARGS__)
+#define XENON_STUDIO_LOG_ERROR(...)									XENON_STUDIO_LOG(::spdlog::level::err, __VA_ARGS__)
+#define XENON_STUDIO_LOG_WARNING(...)								XENON_STUDIO_LOG(::spdlog::level::warn, __VA_ARGS__)
+#define XENON_STUDIO_LOG_INFORMATION(...)							XENON_STUDIO_LOG(::spdlog::level::info, __VA_ARGS__)

--- a/Studio/Studio.cpp
+++ b/Studio/Studio.cpp
@@ -111,7 +111,7 @@ namespace /* anonymous */
 Studio::Studio(Xenon::BackendType type /*= Xenon::BackendType::Any*/)
 	: m_Instance("Xenon Studio", 0, Xenon::RenderTargetType::All, type)
 	, m_Scene(m_Instance, std::make_unique<Xenon::MonoCamera>(m_Instance, 1920, 1080))
-	, m_Renderer(m_Instance, m_Scene.getCamera(), GetRendererTitle(type))
+	, m_Renderer(m_Instance, 1920, 1080, GetRendererTitle(type))
 {
 	XENON_LOG_INFORMATION("Starting the {}", GetRendererTitle(m_Instance.getBackendType()));
 }
@@ -123,16 +123,16 @@ void Studio::run()
 	materialBuidler.addBaseColorTexture();	// Use the sub mesh's one.
 
 	// // Create the occlusion layer for occlusion culling.
-	// auto pOcclusionLayer = m_Renderer.createLayer<Xenon::OcclusionLayer>(m_Scene.getCamera(), g_DefaultRenderingPriority);
+	// auto pOcclusionLayer = m_Renderer.createLayer<Xenon::OcclusionLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight(), g_DefaultRenderingPriority);
 	// pOcclusionLayer->setScene(m_Scene);
 	
 	// Create the shadow map layer.
-	auto pShadowMapLayer = m_Renderer.createLayer<Xenon::Experimental::ShadowMapLayer>(m_Scene.getCamera());
+	auto pShadowMapLayer = m_Renderer.createLayer<Xenon::Experimental::ShadowMapLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight());
 	pShadowMapLayer->setScene(m_Scene);
 
 	// Setup the pipeline.
 #ifdef XENON_DEV_ENABLE_RAY_TRACING
-	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRayTracingLayer>(m_Scene.getCamera());
+	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRayTracingLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight());
 	pRenderTarget->setScene(m_Scene);
 
 	materialBuidler.setRayTracingPipelineSpecification(getRayTracingPipelineSpecification());
@@ -146,7 +146,7 @@ void Studio::run()
 	};
 
 #else 
-	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRasterizingLayer>(m_Scene.getCamera(), g_DefaultRenderingPriority);
+	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRasterizingLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight(), g_DefaultRenderingPriority);
 	pRenderTarget->setScene(m_Scene);
 	// pRenderTarget->setOcclusionLayer(pOcclusionLayer);
 
@@ -175,7 +175,7 @@ void Studio::run()
 	pDiffusionLayer->setSourceImage(pRenderTarget->getColorAttachment());
 
 	// Create the layers.
-	auto pImGui = m_Renderer.createLayer<ImGuiLayer>(m_Scene.getCamera());
+	auto pImGui = m_Renderer.createLayer<ImGuiLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight());
 	pImGui->setScene(m_Scene);
 	// m_Renderer.setScene(m_Scene);
 

--- a/Studio/Studio.cpp
+++ b/Studio/Studio.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "Studio.hpp"
+#include "Logging.hpp"
+
 #include "Layers/ImGuiLayer.hpp"
 
 #include "Xenon/MonoCamera.hpp"
@@ -35,6 +37,8 @@
 #include <glm/gtc/type_ptr.hpp>
 
 constexpr auto g_DefaultRenderingPriority = 5;
+constexpr auto g_DefaultWidth = 1920;
+constexpr auto g_DefaultHeight = 1080;
 
 namespace /* anonymous */
 {
@@ -110,8 +114,8 @@ namespace /* anonymous */
 
 Studio::Studio(Xenon::BackendType type /*= Xenon::BackendType::Any*/)
 	: m_Instance("Xenon Studio", 0, Xenon::RenderTargetType::All, type)
-	, m_Scene(m_Instance, std::make_unique<Xenon::MonoCamera>(m_Instance, 1920, 1080))
-	, m_Renderer(m_Instance, 1920, 1080, GetRendererTitle(type))
+	, m_Scene(m_Instance, std::make_unique<Xenon::MonoCamera>(m_Instance, g_DefaultWidth, g_DefaultHeight))
+	, m_Renderer(m_Instance, g_DefaultWidth, g_DefaultHeight, GetRendererTitle(type))
 {
 	XENON_LOG_INFORMATION("Starting the {}", GetRendererTitle(m_Instance.getBackendType()));
 }
@@ -123,16 +127,16 @@ void Studio::run()
 	materialBuidler.addBaseColorTexture();	// Use the sub mesh's one.
 
 	// // Create the occlusion layer for occlusion culling.
-	// auto pOcclusionLayer = m_Renderer.createLayer<Xenon::OcclusionLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight(), g_DefaultRenderingPriority);
+	// auto pOcclusionLayer = m_Renderer.createLayer<Xenon::OcclusionLayer>(g_DefaultWidth, g_DefaultHeight, g_DefaultRenderingPriority);
 	// pOcclusionLayer->setScene(m_Scene);
-	
+
 	// Create the shadow map layer.
-	auto pShadowMapLayer = m_Renderer.createLayer<Xenon::Experimental::ShadowMapLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight());
+	auto pShadowMapLayer = m_Renderer.createLayer<Xenon::Experimental::ShadowMapLayer>(g_DefaultWidth, g_DefaultHeight);
 	pShadowMapLayer->setScene(m_Scene);
 
 	// Setup the pipeline.
 #ifdef XENON_DEV_ENABLE_RAY_TRACING
-	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRayTracingLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight());
+	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRayTracingLayer>(g_DefaultWidth, g_DefaultHeight);
 	pRenderTarget->setScene(m_Scene);
 
 	materialBuidler.setRayTracingPipelineSpecification(getRayTracingPipelineSpecification());
@@ -146,7 +150,7 @@ void Studio::run()
 	};
 
 #else 
-	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRasterizingLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight(), g_DefaultRenderingPriority);
+	auto pRenderTarget = m_Renderer.createLayer<Xenon::DefaultRasterizingLayer>(g_DefaultWidth, g_DefaultHeight, g_DefaultRenderingPriority);
 	pRenderTarget->setScene(m_Scene);
 	// pRenderTarget->setOcclusionLayer(pOcclusionLayer);
 
@@ -171,11 +175,11 @@ void Studio::run()
 #endif // XENON_DEV_ENABLE_RAY_TRACING
 
 	// Create the diffusion layer.
-	auto pDiffusionLayer = m_Renderer.createLayer<Xenon::Experimental::DiffusionLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight(), pRenderTarget->getPriority());
+	auto pDiffusionLayer = m_Renderer.createLayer<Xenon::Experimental::DiffusionLayer>(g_DefaultWidth, g_DefaultHeight, pRenderTarget->getPriority());
 	pDiffusionLayer->setSourceImage(pRenderTarget->getColorAttachment());
 
 	// Create the layers.
-	auto pImGui = m_Renderer.createLayer<ImGuiLayer>(m_Scene.getCamera()->getWidth(), m_Scene.getCamera()->getHeight());
+	auto pImGui = m_Renderer.createLayer<ImGuiLayer>(g_DefaultWidth, g_DefaultHeight);
 	pImGui->setScene(m_Scene);
 	// m_Renderer.setScene(m_Scene);
 
@@ -194,6 +198,7 @@ void Studio::run()
 
 	{
 		auto ret = Xenon::XObject::GetJobSystem().insert(loaderFunction);
+		XENON_STUDIO_LOG_INFORMATION("Test log!");
 
 		Xenon::FrameTimer timer;
 		do
@@ -330,7 +335,7 @@ void Studio::updateLightSources()
 
 		ImGui::Text("Light ID: %i", Xenon::EnumToInt(group));
 		ImGui::NewLine();
-		
+
 		ImGui::ColorPicker4("Color", glm::value_ptr(light.m_Color));
 		ImGui::NewLine();
 

--- a/Studio/UIComponents/Configuration.cpp
+++ b/Studio/UIComponents/Configuration.cpp
@@ -18,18 +18,18 @@ void Configuration::begin(std::chrono::nanoseconds delta)
 			ImGui::Text("Camera Position Control");
 			ImGui::Separator();
 
-			ImGui::InputFloat3("Position", glm::value_ptr(m_pImGuiLayer->getRenderer().getCamera()->m_Position));
-			ImGui::InputFloat3("Camera Up", glm::value_ptr(m_pImGuiLayer->getRenderer().getCamera()->m_Up));
-			ImGui::InputFloat3("Camera Front", glm::value_ptr(m_pImGuiLayer->getRenderer().getCamera()->m_Front));
-			ImGui::InputFloat3("Camera Right", glm::value_ptr(m_pImGuiLayer->getRenderer().getCamera()->m_Right));
-			ImGui::InputFloat3("Word Up", glm::value_ptr(m_pImGuiLayer->getRenderer().getCamera()->m_WorldUp));
+			ImGui::InputFloat3("Position", glm::value_ptr(m_pImGuiLayer->getScene()->getCamera()->m_Position));
+			ImGui::InputFloat3("Camera Up", glm::value_ptr(m_pImGuiLayer->getScene()->getCamera()->m_Up));
+			ImGui::InputFloat3("Camera Front", glm::value_ptr(m_pImGuiLayer->getScene()->getCamera()->m_Front));
+			ImGui::InputFloat3("Camera Right", glm::value_ptr(m_pImGuiLayer->getScene()->getCamera()->m_Right));
+			ImGui::InputFloat3("Word Up", glm::value_ptr(m_pImGuiLayer->getScene()->getCamera()->m_WorldUp));
 
 			ImGui::Spacing();
 			ImGui::Text("Camera Movement Control");
 			ImGui::Separator();
 
-			ImGui::SliderFloat("Movement Bias", &m_pImGuiLayer->getRenderer().getCamera()->m_MovementBias, 0.0f, 100.0f);
-			ImGui::SliderFloat("Rotation Bias", &m_pImGuiLayer->getRenderer().getCamera()->m_RotationBias, 0.0f, 100.0f);
+			ImGui::SliderFloat("Movement Bias", &m_pImGuiLayer->getScene()->getCamera()->m_MovementBias, 0.0f, 100.0f);
+			ImGui::SliderFloat("Rotation Bias", &m_pImGuiLayer->getScene()->getCamera()->m_RotationBias, 0.0f, 100.0f);
 		}
 
 		ImGui::End();

--- a/Studio/UIComponents/Logs.cpp
+++ b/Studio/UIComponents/Logs.cpp
@@ -5,6 +5,11 @@
 
 #include <imgui.h>
 
+#ifdef XENON_DEBUG
+#include <iostream>
+
+#endif // XENON_DEBUG
+
 void Logs::begin(std::chrono::nanoseconds delta)
 {
 	if (m_bIsOpen)

--- a/Studio/UIComponents/Logs.cpp
+++ b/Studio/UIComponents/Logs.cpp
@@ -5,11 +5,6 @@
 
 #include <imgui.h>
 
-#ifdef XENON_DEBUG
-#include <iostream>
-
-#endif // XENON_DEBUG
-
 void Logs::begin(std::chrono::nanoseconds delta)
 {
 	if (m_bIsOpen)


### PR DESCRIPTION
We previously used to depend on the camera unwantedly. For example, we even used it for the backend render targets when we just need the width and height. This is now fixed in both the backend(s) and the front end. This is also fixed in the XenonStudio as well.

Also fixed the XenonStudio's logging UI and it now has its logging framework.